### PR TITLE
[Feat] #429 메트로놈 화면 UI 변경

### DIFF
--- a/Macro/Screen/MetronomeScreen/HanbaeBoardView.swift
+++ b/Macro/Screen/MetronomeScreen/HanbaeBoardView.swift
@@ -45,7 +45,6 @@ struct HanbaeBoardView: View {
                 }
             }
         }
-        .frame(height: 300)
     }
 }
 

--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -19,74 +19,74 @@ struct MetronomeControlView: View {
         ZStack {
             VStack(alignment: .center, spacing: 0) {
                 // 위에 드래그 제스쳐 되어야 하는 영역
-                ZStack {
+                VStack(alignment: .center, spacing: 10) {
+                    if !self.viewModel.state.isTapping {
+                        Text("빠르기(BPM)")
+                            .font(.Callout_R)
+                            .foregroundStyle(.textTertiary)
+                            .padding(.vertical, 5)
+                    } else {
+                        Text("원하는 빠르기로 계속 탭해주세요")
+                            .font(.Body_SB)
+                            .foregroundStyle(.textDefault)
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 16)
+                            .background(.backgroundDefault)
+                            .cornerRadius(8)
+                    }
+                    
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(self.viewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                            .frame(width: 56)
+                            .overlay {
+                                Image(systemName: "minus")
+                                    .font(.system(size: 26))
+                                    .foregroundStyle(.textButtonSecondary)
+                            }
+                            .onTapGesture {
+                                isChangeBpm = true
+                                tapOnceAction(isIncreasing: false)
+                            }
+                            .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
+                                isChangeBpm = true
+                                tapTwiceAction(isIncreasing: false, isPressing: isPressing)
+                            }, perform: {})
+                        
+                        Text("\(self.viewModel.state.bpm)")
+                            .font(.custom("Pretendard-Medium", fixedSize: 64))
+                            .foregroundStyle(self.viewModel.state.isTapping ? .textBPMSearch : .textSecondary)
+                            .frame(width: 120, height: 60)
+                            .padding(8)
+                            .background(self.viewModel.state.isTapping ? .backgroundDefault : .clear)
+                            .cornerRadius(16)
+                        
+                        Circle()
+                            .fill(self.viewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                            .frame(width: 56)
+                            .overlay {
+                                Image(systemName: "plus")
+                                    .font(.system(size: 26))
+                                    .foregroundStyle(.textButtonSecondary)
+                            }
+                            .onTapGesture {
+                                isChangeBpm = true
+                                tapOnceAction(isIncreasing: true)
+                            }
+                            .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
+                                isChangeBpm = true
+                                tapTwiceAction(isIncreasing: true, isPressing: isPressing)
+                            }, perform: {})
+                    }
+                    .sensoryFeedback(.selection, trigger: self.viewModel.state.bpm) { _, _ in
+                        return isChangeBpm
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(EdgeInsets(top: 28, leading: 0, bottom: 32, trailing: 0))
+                .background {
                     Rectangle()
                         .foregroundStyle(.backgroundCard)
-                    
-                    VStack(alignment: .center, spacing: 10) {
-                        if !self.viewModel.state.isTapping {
-                            Text("빠르기(BPM)")
-                                .font(.Callout_R)
-                                .foregroundStyle(.textTertiary)
-                                .padding(.vertical, 5)
-                        } else {
-                            Text("원하는 빠르기로 계속 탭해주세요")
-                                .font(.Body_SB)
-                                .foregroundStyle(.textDefault)
-                                .padding(.vertical, 5)
-                                .padding(.horizontal, 16)
-                                .background(.backgroundDefault)
-                                .cornerRadius(8)
-                        }
-                        
-                        HStack(spacing: 12) {
-                            Circle()
-                                .fill(self.viewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
-                                .frame(width: 56)
-                                .overlay {
-                                    Image(systemName: "minus")
-                                        .font(.system(size: 26))
-                                        .foregroundStyle(.textButtonSecondary)
-                                }
-                                .onTapGesture {
-                                    isChangeBpm = true
-                                    tapOnceAction(isIncreasing: false)
-                                }
-                                .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
-                                    isChangeBpm = true
-                                    tapTwiceAction(isIncreasing: false, isPressing: isPressing)
-                                }, perform: {})
-                            
-                            Text("\(self.viewModel.state.bpm)")
-                                .font(.custom("Pretendard-Medium", fixedSize: 64))
-                                .foregroundStyle(self.viewModel.state.isTapping ? .textBPMSearch : .textSecondary)
-                                .frame(width: 120, height: 60)
-                                .padding(8)
-                                .background(self.viewModel.state.isTapping ? .backgroundDefault : .clear)
-                                .cornerRadius(16)
-                            
-                            Circle()
-                                .fill(self.viewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
-                                .frame(width: 56)
-                                .overlay {
-                                    Image(systemName: "plus")
-                                        .font(.system(size: 26))
-                                        .foregroundStyle(.textButtonSecondary)
-                                }
-                                .onTapGesture {
-                                    isChangeBpm = true
-                                    tapOnceAction(isIncreasing: true)
-                                }
-                                .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
-                                    isChangeBpm = true
-                                    tapTwiceAction(isIncreasing: true, isPressing: isPressing)
-                                }, perform: {})
-                        }
-                        .sensoryFeedback(.selection, trigger: self.viewModel.state.bpm) { _, _ in
-                            return isChangeBpm
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
                 }
                 .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, topTrailingRadius: 12))
                 .gesture(
@@ -231,4 +231,8 @@ struct MetronomeControlView: View {
         self.viewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: false))
         self.viewModel.effect(action: .setPreviousTranslation(position: 0))
     }
+}
+
+#Preview {
+    MetronomeControlView()
 }

--- a/Macro/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeView.swift
@@ -35,11 +35,13 @@ struct MetronomeView: View {
                 }
                 if let sobakSegmentCount = self.viewModel.state.currentJangdanType?.sobakSegmentCount {
                     SobakSegmentsView(sobakSegmentCount: sobakSegmentCount, currentSobak: self.viewModel.state.currentSobak, isPlaying: self.viewModel.state.isPlaying, isSobakOn: self.viewModel.state.isSobakOn)
-                        .padding(.bottom, -4)
                 }
             }
-            .frame(height: 372)
-            .padding(.horizontal, 8)
+            .padding(
+                self.viewModel.state.currentJangdanType?.sobakSegmentCount == nil
+                ? EdgeInsets(top: 36, leading: 8, bottom: 36, trailing: 8)
+                : EdgeInsets(top: 24, leading: 8, bottom: 16, trailing: 8)
+            )
             
             // MARK: 2. 소박 듣기, 소박 보기 뷰
             MetronomeSettingControlView(appState: DIContainer.shared.appState, viewModel: self.viewModel)


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #429  -->

## 작업 내용
### 1. 한배보드 변경
- 기존에 고정된 height 값을 삭제했습니다.
- 기존 height가 고정되어 있어서 필요하지 않았던 상하 padding을 추가했습니다.
  - 소박보기 여부에 따라 분기처리함

### 2. 컨트롤 패널 변경
- 기존에는 ZStack으로 구현되어 있어 높이가 고정되어 있지 않았음
- 배경 Rectangle을 .background 로 이동
- 내부 컨텐츠 (BPM, +/- 버튼) 에 상하좌우 padding

## 비고 <!-- (Optional) -->

불편해서 Preview 추가함

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?