### PR TITLE
[Feat] #432 FoldToggle 버튼 구현

### DIFF
--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -88,7 +88,6 @@ struct MetronomeControlView: View {
                     Rectangle()
                         .foregroundStyle(.backgroundCard)
                 }
-                .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, topTrailingRadius: 12))
                 .gesture(
                     DragGesture()
                         .onChanged { gesture in
@@ -129,8 +128,8 @@ struct MetronomeControlView: View {
                 .padding(.horizontal, 12)
                 .padding(.bottom, 24)
                 .background(.backgroundCard)
-                .clipShape(UnevenRoundedRectangle(bottomLeadingRadius: 24, bottomTrailingRadius: 24))
             }
+            .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, bottomLeadingRadius: 24, bottomTrailingRadius: 24))
         }
         .padding(.horizontal, 16)
     }

--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -16,7 +16,23 @@ struct MetronomeControlView: View {
     @State private var isChangeBpm: Bool = false
     
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topTrailing) {
+            Button {
+                
+            } label: {
+                Image(systemName: "chevron.up")
+                    .foregroundStyle(.textQuaternary)
+                    .frame(width: 24, height: 24)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 6)
+                    .background {
+                        UnevenRoundedRectangle(topLeadingRadius: 12, topTrailingRadius: 12)
+                            .foregroundStyle(.backgroundCard)
+                    }
+            }
+            .buttonStyle(.plain)
+            .offset(y: -36)
+            
             VStack(alignment: .center, spacing: 0) {
                 // 위에 드래그 제스쳐 되어야 하는 영역
                 VStack(alignment: .center, spacing: 10) {

--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -43,11 +43,13 @@ struct MetronomeControlView: View {
             
             // 드래그 제스쳐 되어야 하는 영역 - BPM
             layout {
-                if isFold {
+                if isFold { // 접힌 BPM
                     HStack(spacing: 0) {
                         Image(systemName: "minus")
                             .font(.system(size: 17))
                             .foregroundStyle(.textQuaternary)
+                            .frame(width: 16, height: 16)
+                            .contentShape(Rectangle())
                             .onTapGesture {
                                 isChangeBpm = true
                                 tapOnceAction(isIncreasing: false)
@@ -70,6 +72,8 @@ struct MetronomeControlView: View {
                         Image(systemName: "plus")
                             .font(.system(size: 17))
                             .foregroundStyle(.textQuaternary)
+                            .frame(width: 16, height: 16)
+                            .contentShape(Rectangle())
                             .onTapGesture {
                                 isChangeBpm = true
                                 tapOnceAction(isIncreasing: true)
@@ -85,6 +89,7 @@ struct MetronomeControlView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(EdgeInsets(top: 31, leading: 21, bottom: 31, trailing: 21))
+                    .contentShape(Rectangle())
                     .gesture(
                         DragGesture()
                             .onChanged { gesture in
@@ -95,7 +100,7 @@ struct MetronomeControlView: View {
                                 dragEnded()
                             }
                     )
-                } else {
+                } else { // 기본 BPM
                     VStack(alignment: .center, spacing: 10) {
                         if !self.viewModel.state.isTapping {
                             Text("빠르기(BPM)")
@@ -164,6 +169,7 @@ struct MetronomeControlView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(EdgeInsets(top: 28, leading: 0, bottom: 32, trailing: 0))
+                    .contentShape(Rectangle())
                     .gesture(
                         DragGesture()
                             .onChanged { gesture in

--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -41,33 +41,13 @@ struct MetronomeControlView: View {
             ? AnyLayout(HStackLayout(spacing: 0))
             : AnyLayout(VStackLayout(alignment: .center, spacing: 0))
             
+            // 드래그 제스쳐 되어야 하는 영역 - BPM
             layout {
-                // 위에 드래그 제스쳐 되어야 하는 영역
-                VStack(alignment: .center, spacing: 10) {
-                    if !self.viewModel.state.isTapping {
-                        Text("빠르기(BPM)")
-                            .font(.Callout_R)
-                            .foregroundStyle(.textTertiary)
-                            .padding(.vertical, 5)
-                    } else {
-                        Text("원하는 빠르기로 계속 탭해주세요")
-                            .font(.Body_SB)
-                            .foregroundStyle(.textDefault)
-                            .padding(.vertical, 5)
-                            .padding(.horizontal, 16)
-                            .background(.backgroundDefault)
-                            .cornerRadius(8)
-                    }
-                    
-                    HStack(spacing: 12) {
-                        Circle()
-                            .fill(self.viewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
-                            .frame(width: 56)
-                            .overlay {
-                                Image(systemName: "minus")
-                                    .font(.system(size: 26))
-                                    .foregroundStyle(.textButtonSecondary)
-                            }
+                if isFold {
+                    HStack(spacing: 0) {
+                        Image(systemName: "minus")
+                            .font(.system(size: 17))
+                            .foregroundStyle(.textQuaternary)
                             .onTapGesture {
                                 isChangeBpm = true
                                 tapOnceAction(isIncreasing: false)
@@ -76,23 +56,20 @@ struct MetronomeControlView: View {
                                 isChangeBpm = true
                                 tapTwiceAction(isIncreasing: false, isPressing: isPressing)
                             }, perform: {})
+                            .matchedGeometryEffect(id: "minusButton", in: animationNamespace)
                         
                         Text("\(self.viewModel.state.bpm)")
-                            .font(.custom("Pretendard-Medium", fixedSize: 64))
+                            .font(.custom("Pretendard-Medium", fixedSize: 44))
                             .foregroundStyle(self.viewModel.state.isTapping ? .textBPMSearch : .textSecondary)
-                            .frame(width: 120, height: 60)
+                            .frame(width: 100)
                             .padding(8)
                             .background(self.viewModel.state.isTapping ? .backgroundDefault : .clear)
                             .cornerRadius(16)
+                            .matchedGeometryEffect(id: "bpm", in: animationNamespace)
                         
-                        Circle()
-                            .fill(self.viewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
-                            .frame(width: 56)
-                            .overlay {
-                                Image(systemName: "plus")
-                                    .font(.system(size: 26))
-                                    .foregroundStyle(.textButtonSecondary)
-                            }
+                        Image(systemName: "plus")
+                            .font(.system(size: 17))
+                            .foregroundStyle(.textQuaternary)
                             .onTapGesture {
                                 isChangeBpm = true
                                 tapOnceAction(isIncreasing: true)
@@ -101,23 +78,103 @@ struct MetronomeControlView: View {
                                 isChangeBpm = true
                                 tapTwiceAction(isIncreasing: true, isPressing: isPressing)
                             }, perform: {})
+                            .matchedGeometryEffect(id: "plusButton", in: animationNamespace)
                     }
                     .sensoryFeedback(.selection, trigger: self.viewModel.state.bpm) { _, _ in
                         return isChangeBpm
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(EdgeInsets(top: 31, leading: 21, bottom: 31, trailing: 21))
+                    .gesture(
+                        DragGesture()
+                            .onChanged { gesture in
+                                isChangeBpm = true
+                                dragAction(gesture: gesture)
+                            }
+                            .onEnded { _ in
+                                dragEnded()
+                            }
+                    )
+                } else {
+                    VStack(alignment: .center, spacing: 10) {
+                        if !self.viewModel.state.isTapping {
+                            Text("빠르기(BPM)")
+                                .font(.Callout_R)
+                                .foregroundStyle(.textTertiary)
+                                .padding(.vertical, 5)
+                        } else {
+                            Text("원하는 빠르기로 계속 탭해주세요")
+                                .font(.Body_SB)
+                                .foregroundStyle(.textDefault)
+                                .padding(.vertical, 5)
+                                .padding(.horizontal, 16)
+                                .background(.backgroundDefault)
+                                .cornerRadius(8)
+                        }
+                        
+                        HStack(spacing: 12) {
+                            Circle()
+                                .fill(self.viewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                                .frame(width: 56)
+                                .overlay {
+                                    Image(systemName: "minus")
+                                        .font(.system(size: 26))
+                                        .foregroundStyle(.textButtonSecondary)
+                                }
+                                .onTapGesture {
+                                    isChangeBpm = true
+                                    tapOnceAction(isIncreasing: false)
+                                }
+                                .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
+                                    isChangeBpm = true
+                                    tapTwiceAction(isIncreasing: false, isPressing: isPressing)
+                                }, perform: {})
+                                .matchedGeometryEffect(id: "minusButton", in: animationNamespace)
+                            
+                            Text("\(self.viewModel.state.bpm)")
+                                .font(.custom("Pretendard-Medium", fixedSize: 64))
+                                .foregroundStyle(self.viewModel.state.isTapping ? .textBPMSearch : .textSecondary)
+                                .frame(width: 120, height: 60)
+                                .padding(8)
+                                .background(self.viewModel.state.isTapping ? .backgroundDefault : .clear)
+                                .cornerRadius(16)
+                                .matchedGeometryEffect(id: "bpm", in: animationNamespace)
+                            
+                            Circle()
+                                .fill(self.viewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                                .frame(width: 56)
+                                .overlay {
+                                    Image(systemName: "plus")
+                                        .font(.system(size: 26))
+                                        .foregroundStyle(.textButtonSecondary)
+                                }
+                                .onTapGesture {
+                                    isChangeBpm = true
+                                    tapOnceAction(isIncreasing: true)
+                                }
+                                .onLongPressGesture(minimumDuration: 0.5, pressing: { isPressing in
+                                    isChangeBpm = true
+                                    tapTwiceAction(isIncreasing: true, isPressing: isPressing)
+                                }, perform: {})
+                                .matchedGeometryEffect(id: "plusButton", in: animationNamespace)
+                        }
+                        .sensoryFeedback(.selection, trigger: self.viewModel.state.bpm) { _, _ in
+                            return isChangeBpm
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(EdgeInsets(top: 28, leading: 0, bottom: 32, trailing: 0))
+                    .gesture(
+                        DragGesture()
+                            .onChanged { gesture in
+                                isChangeBpm = true
+                                dragAction(gesture: gesture)
+                            }
+                            .onEnded { _ in
+                                dragEnded()
+                            }
+                    )
                 }
-                .frame(maxWidth: .infinity)
-                .padding(EdgeInsets(top: 28, leading: 0, bottom: 32, trailing: 0))
-                .gesture(
-                    DragGesture()
-                        .onChanged { gesture in
-                            isChangeBpm = true
-                            dragAction(gesture: gesture)
-                        }
-                        .onEnded { _ in
-                            dragEnded()
-                        }
-                )
                 
                 // 아래 시작, 탭 버튼
                 HStack(spacing: isFold ? 8 : 12) {
@@ -161,14 +218,19 @@ struct MetronomeControlView: View {
                         }
                         .sensoryFeedback(.impact(flexibility: .rigid), trigger: self.tapFeedback)
                 }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 24)
+                .padding(
+                    isFold
+                    ? EdgeInsets(top: 24, leading: 0, bottom: 24, trailing: 12)
+                    : EdgeInsets(top: 0, leading: 12, bottom: 24, trailing: 12)
+                )
             }
             .background {
                 Rectangle()
                     .foregroundStyle(.backgroundCard)
             }
-            .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, bottomLeadingRadius: 24, bottomTrailingRadius: 24))
+            .clipShape(
+                UnevenRoundedRectangle(topLeadingRadius: 12, bottomLeadingRadius: 24, bottomTrailingRadius: 24)
+            )
         }
         .padding(.horizontal, 16)
     }

--- a/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
@@ -47,10 +47,11 @@ struct MetronomeSettingControlView: View {
                     }
                 }
             } label: {
-                HStack(spacing: 6) {
+                HStack(spacing: 0) {
                     Image(systemName: "speaker.wave.2.fill")
                     
                     Text(self.appState.selectedInstrument.rawValue)
+                        .font(.Body_R)
                 }
             }
             .buttonStyle(MetronomeSettingMenuButtonStyle())
@@ -75,7 +76,7 @@ extension MetronomeSettingControlView {
                     .font(.title3)
                     .foregroundStyle(isOn ? Color.buttonToggleOn : Color.textSecondary)
             }
-            .frame(height: 56)
+            .frame(height: 48)
             .onChange(of: configuration.isPressed) { _, newValue in
                 if newValue {
                     isOn.toggle()
@@ -97,7 +98,7 @@ extension MetronomeSettingControlView {
                     .font(.title3)
                     .foregroundStyle(isActive ? Color.buttonToggleOn : Color.textSecondary)
             }
-            .frame(height: 56)
+            .frame(height: 48)
             .onChange(of: configuration.isPressed) { _, newValue in
                 isActive = newValue
             }

--- a/Macro/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeView.swift
@@ -44,7 +44,12 @@ struct MetronomeView: View {
             )
             
             // MARK: 2. 소박 듣기, 소박 보기 뷰
-            MetronomeSettingControlView(appState: DIContainer.shared.appState, viewModel: self.viewModel)
+            HStack(spacing: 14) {
+                MetronomeSettingControlView(appState: DIContainer.shared.appState, viewModel: self.viewModel)
+                
+                Spacer()
+                    .frame(width: 60)
+            }
             
             // MARK: 3. BPM 및 재생 조절 뷰
             MetronomeControlView()


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #432  -->

## 작업 내용
### 1. Setting Control 패널들 수정
- 높이 변경: 56 -> 48
- 폰트 변경: Body_Regular
- 외부(MetronomeView)에서 사용할때 우측 Toggle Button 여유분 추가
  - 일단 Figma 기준 SettingControl 패널과 Control 패널의 배치를 따르고 싶었음
  - SettingControlView 내부에서 처리할 경우
    - 나중에 토글버튼 변경될 때 SettingControlView도 수정해야 한다는 점이 거슬렸음
  - 세팅컨트롤 + 컨트롤 통합하지 않은 이유
    - 나중에 변경할 때 서로 다른 이유로 변경될 것 같아서 분리된 상태로 놔두기로 결정함

### 2. FoldToggle 버튼 추가
- 화면 레이아웃 살짝 변경
  - BPM 부분이랑 버튼 부분 배경이 따로 처리되어있어 통합함
    - 애니메이션이 매끄럽게 보이도록 하기 위해
- 토글버튼 추가
  - ZStack으로 TopTrailing 정렬 후 offset 주는 방식으로 구현
    - ControlView 내부에서 관리하고 싶었고
    - 고정된 크기의 View라서 offset 주는게 간단햇음
- 토글 적용
  - 시작 / 탭 버튼의 경우 그냥 3항연산자로 처리함
    - 변경사항이 별로 없었고 간단했음
  - BPM 조절 영역의 경우 isFold 여부에 따라 분기처리함
    - 변경사항이 너무 많았고 사실상 다른 UI 라고 생각했음
    - 나중에 수정할 때 어디를 변경해야 하는지 찾기 쉽지 않을까 라고 생각함
- Dynamin Layout
  - HStack, VStack을 AnyLayout으로 감싸서 분기처리 하는 방식
  - 레이아웃 변동에 따른 애니메이션을 자동으로 처리해줌
- 애니메이션
  - 서로 다른 두 컴포넌트를 연결하고 싶을 때 같은 네임스페이스의 같은 id 라면 같은 컴포넌트로 처리됨
  - .matchedGeometryEffect(id:, namespace:)
- 토글버튼 애니메이션
  - Image(systemName: ) 에서 systemName을 분기처리하면 전,후 이미지를 다른 컴포넌트로 인식하나봄
  - 그래서 rotateEffect로 180도 회전시킴

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

https://github.com/user-attachments/assets/76cd79d3-829c-454a-9b16-6091928157e9


### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?