### PR TITLE
[Fix] #448 장단 삭제시 해당 장단 재생 정지

### DIFF
--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -217,6 +217,7 @@ struct CustomJangdanPracticeView: View {
                         Button("삭제", role: .destructive) {
                             self.deleteJangdanAlert = false
                             self.viewModel.effect(action: .deleteCustomJangdanData(jangdanName: jangdanName))
+                            self.viewModel.effect(action: .exitMetronome)
                             self.router.pop()
                         }
                     } message: {


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
커스텀 장단을 삭제할 때 해당 장단을 정지하고 메트로놈 화면을 벗어나도록 수정했습니다.

<!-- Close #448  -->

## 작업 내용
### 1. 메트로놈 정지
- 커스텀 장단 연습 화면에서 장단 삭제시 메트로놈을 중지하는 코드 추가
- TemplateUseCase 에서 처리할까 잠깐 고민함
  - UseCase 레벨에서 처리하려면 의존성이 추가되는 문제 발생
  - 책임 관리 측면에서 ViewModel에서 처리하는게 옳다고 생각
  - 이상 2가지 이유로 ViewModel에서 처리함
- 다른 메트로놈 화면들 (빌트인, 커스텀장단생성) 에서는 장단을 삭제할 필요가 없어서 작업 필요성 없음

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?