### PR TITLE
[Fix] #454 장단 삭제시 홈화면 상단 네비바 이슈

### DIFF
--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -217,7 +217,7 @@ struct CustomJangdanPracticeView: View {
                         Button("삭제", role: .destructive) {
                             self.deleteJangdanAlert = false
                             self.viewModel.effect(action: .deleteCustomJangdanData(jangdanName: jangdanName))
-                            self.router.pop()
+                            self.dismiss()
                         }
                     } message: {
                         Text("현재 장단을 삭제하시겠습니까?")


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
https://www.notion.so/22c2efe244228080a3b0c6358b36e91f?source=copy_link
장단 삭제시 홈화면에 네비게이션바가 임시로 생가는 현상

<!-- Close #454  -->

## 작업 내용
### 1. 원인
- 화면 이탈을 라우터를 통해서 함
- 라우터(NavigationStack) 사용하다보니 네비바가 보임

### 2. 해결
- 화면 이탈 방식을 dismiss()로 변경
- 단순히 View가 사라지는거라 이제는 네비바가 안생김 (맞나)

### 3. 의문
- 그냥 HomeView에서 .navigationBarHidden(true) 다는걸론 해결이 안됨
- 왜지

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?