### PR TITLE
[Fix] #460 키보드 출현시 화면 밀려올라가는 이슈

### DIFF
--- a/Macro/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeView.swift
@@ -59,10 +59,10 @@ struct MetronomeView: View {
         .onTapGesture {
             self.viewModel.effect(action: .disableEstimateBpm)
         }
-        
         .task {
             self.viewModel.effect(action: .selectJangdan(selectedJangdanName: self.jangdanName))
         }
+        .ignoresSafeArea(.keyboard)
     }
 }
 


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #460  -->

## 작업 내용
### 1. 해결
- SwiftUI가 키보드를 safeArea 취급하기 때문
- 키보드 영역을 무시해버리면 해결
- 최상단인 HomeView 는 스크롤뷰라 상관 없었고
- MetronomeView가 반응형 레이아웃이라 MetronomeView에만 적용함

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
<img width="1179" height="2556" alt="IMG_4371" src="https://github.com/user-attachments/assets/6f52cd72-7332-4a31-b5bb-1d828cfd8a0d" />

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?