### PR TITLE
[Fix] #474 사운드 밀림 현상

### DIFF
--- a/Hanbae/Domain/UseCase/Interface/PlaySoundInterface.swift
+++ b/Hanbae/Domain/UseCase/Interface/PlaySoundInterface.swift
@@ -10,7 +10,8 @@ import Combine
 // 소리내는 UseCase용
 protocol PlaySoundInterface {
     var callInterruptPublisher: AnyPublisher<Void, Never> { get }
-    func audioEngineStart()
+    func prepareAudioEngine()
+    func pauseAudioEngine()
     func beep(_ accent: Accent)
     func setSoundType()
 }

--- a/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -106,7 +106,7 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     
     func play() {
         // AudioEngine start()
-        self.soundManager.audioEngineStart()
+        self.soundManager.prepareAudioEngine()
         // 데이터 갱신
         self.currentBeatIndex = 0
         self.initialDaeSoBakIndex()
@@ -128,6 +128,7 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     }
     
     func stop() {
+        self.soundManager.pauseAudioEngine()
         UIApplication.shared.isIdleTimerDisabled = false
         self.timer?.cancel()
         self.timer = nil

--- a/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -111,10 +111,14 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         self.currentBeatIndex = 0
         self.initialDaeSoBakIndex()
         UIApplication.shared.isIdleTimerDisabled = true
+        
+        let deadline: DispatchTime = .now() + self.interval
+        self.timerHandler()
+        
         // Timer 설정
         if self.timer != nil { self.stop() }
         self.timer = DispatchSource.makeTimerSource(queue: self.queue)
-        self.timer?.schedule(deadline: .now(), repeating: self.interval, leeway: .nanoseconds(1))
+        self.timer?.schedule(deadline: deadline, repeating: self.interval, leeway: .nanoseconds(1))
         self.timer?.setEventHandler { [weak self] in
             guard let self = self else { return }
             self.lastPlayTime = .now
@@ -123,6 +127,7 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         
         // play 여부 publish
         self.isPlayingSubject.send(true)
+        
         // Timer 실행
         self.timer?.resume()
     }

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -48,7 +48,7 @@ class SoundManager {
         self.setSoundType()
         
         // 엔진 시작
-        self.audioEngineStart()
+        self.prepareAudioEngine()
         
         // 전화 송/수신 시 interrupt 여부를 감지를 위한 notificationCenter 생성
         self.setupNotifications()
@@ -75,7 +75,7 @@ class SoundManager {
             self.engine.stop()
             
         case .ended:
-            self.audioEngineStart()
+            self.prepareAudioEngine()
             do {
                 try self.audioSession.setActive(true)
             } catch {
@@ -137,7 +137,7 @@ extension SoundManager: PlaySoundInterface {
         publisher.eraseToAnyPublisher()
     }
     
-    func audioEngineStart() {
+    func prepareAudioEngine() {
         if !self.engine.isRunning {
             do {
                 try self.engine.start()
@@ -147,6 +147,10 @@ extension SoundManager: PlaySoundInterface {
         }
         self.engine.prepare()
         lastBeepTime = nil
+    }
+    
+    func pauseAudioEngine() {
+        self.engine.pause()
     }
 
     func beep(_ accent: Accent) {

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -76,7 +76,13 @@ class SoundManager {
             
         case .ended:
             self.audioEngineStart()
-        default: ()
+            do {
+                try self.audioSession.setActive(true)
+            } catch {
+                print("SoundManager: 오디오 세션 재활성화 중 에러 발생 - \(error)")
+                return
+            }
+        default: break
         }
     }
     

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -129,6 +129,7 @@ extension SoundManager: PlaySoundInterface {
                 print("오디오 엔진 시작 및 재시작 실패: \(error.localizedDescription)")
             }
         }
+        self.engine.prepare()
     }
 
     func beep(_ accent: Accent) {

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -47,16 +47,8 @@ class SoundManager {
         // SoundType에 따라 configureSoundPlayers 구성
         self.setSoundType()
         
-        // 더미 노드 생성 및 연결
-        let dummyNode = AVAudioPlayerNode()
-        self.engine.attach(dummyNode)
-        self.engine.connect(dummyNode, to: self.engine.mainMixerNode, format: nil)
-        
         // 엔진 시작
         self.audioEngineStart()
-        
-        // 더미 노드 분리
-        self.engine.detach(dummyNode)
         
         // 전화 송/수신 시 interrupt 여부를 감지를 위한 notificationCenter 생성
         self.setupNotifications()

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Combine
 import AVFoundation
+import OSLog
 
 class SoundManager {
     
@@ -19,6 +20,9 @@ class SoundManager {
     private var soundType: SoundType
     
     private var publisher: PassthroughSubject<Void, Never> = .init()
+    
+    private var lastBeepTime: CFAbsoluteTime?
+    private var logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Macro", category: "SoundManager")
     
     init?(appState: AppState) {
         self.appState = appState
@@ -130,9 +134,16 @@ extension SoundManager: PlaySoundInterface {
             }
         }
         self.engine.prepare()
+        lastBeepTime = nil
     }
 
     func beep(_ accent: Accent) {
+        let currentTime = CFAbsoluteTimeGetCurrent()
+        if let lastTime = self.lastBeepTime {
+            let interval = currentTime - lastTime
+            logger.log("Beep interval: \(String(format: "%.4f", interval)) seconds")
+        }
+        lastBeepTime = currentTime
         
         guard let buffer = self.audioBuffers[accent] else { return }
         

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import Combine
 import AVFoundation
-import OSLog
 
 class SoundManager {
     
@@ -23,9 +22,6 @@ class SoundManager {
     private var soundType: SoundType
     
     private var publisher: PassthroughSubject<Void, Never> = .init()
-    
-    private var lastBeepTime: CFAbsoluteTime?
-    private var logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Macro", category: "SoundManager")
     
     init?(appState: AppState) {
         self.appState = appState
@@ -146,7 +142,6 @@ extension SoundManager: PlaySoundInterface {
             }
         }
         self.engine.prepare()
-        lastBeepTime = nil
     }
     
     func pauseAudioEngine() {
@@ -154,13 +149,6 @@ extension SoundManager: PlaySoundInterface {
     }
 
     func beep(_ accent: Accent) {
-        let currentTime = CFAbsoluteTimeGetCurrent()
-        if let lastTime = self.lastBeepTime {
-            let interval = currentTime - lastTime
-            logger.log("Beep interval: \(String(format: "%.4f", interval)) seconds")
-        }
-        lastBeepTime = currentTime
-        
         guard let buffer = self.audioBuffers[accent] else { return }
         
         let playerNode = self.playerNodePool[self.poolIndex]

--- a/Hanbae/Service/SoundManager.swift
+++ b/Hanbae/Service/SoundManager.swift
@@ -34,7 +34,7 @@ class SoundManager {
         
         // AudioSession 설정
         do {
-            try self.audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .defaultToSpeaker, .allowBluetoothA2DP])
+            try self.audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .allowBluetoothA2DP])
             try self.audioSession.setActive(true)
         } catch {
             print("SoundManager: 오디오 세션 설정 중 에러 발생 - \(error)")


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
사운드 관련 이슈들 에 대한 해결 시도
1. 재생 중 불규칙적인 사운드 딜레이
2. 블루투스 환경에서 사운드 딜레이
3. 첫 박 딜레이

<!-- Close #474  -->

## 작업 내용
### 1. 재생 중 사운드 딜레이
- 짐작 원인 : AudioEngine 사용 중 발생하는 오버헤드
- 시도한 해결책 : 오버헤드 최소화
- 방안
  1. 엔진의 start/stop 대신 prepare/pause 사용
      - 엔진은 켜져있는 상태로 유지하면서 재생 관련 이벤트를 처리하도록 변경
  2. 매 beep마다 playerNode 생성하지 않도록 변경
      - 미리 playerNode를 준비시켜놓고 준비되어있는 node를 활용하는 방식으로 변경
      - Accent 마다 playerNode를 대응시킨 Dictionary 방식으로 저장할 경우 소리가 중첩될 때 재생중인 소리가 끊기는 이슈 발생
      - PlayerNode를 미리 10개 준비시켜둔 pool을 만들어서 순차적으로 하나씩 꺼내다 쓰는 기법 활용 = playerNodePool
      - 왜 10개냐면 소리가 10번씩 중첩되진 않을거라서..
      - 따라서 beep 함수 내부에서 node를 세팅하고 detach 하는 과정이 필요 없어짐

### 2. Bluetooth 환경 딜레이
- 짐작 원인 : AudioSession의 defaultToSpeaker 옵션
- 해결책 : 해당 옵션 제거
- 에어팟에선 오류 재현이 안돼서 검증 필요

### 3. 첫 박 딜레이
- 짐작 원인 : AudioEngine에서 첫 박 재생하기 위한 예열과정에 따른 딜레이
- 시도한 해결책 : 재생 직전 볼륨 0으로 미리 사운드 1회 재생
- 해결되지 않음
- 짐작 원인 2 : beep 함수를 호출하는 timer 설정 과정에 필요한 시간에 따른 딜레이
- 시도한 해결책 : 그럼 타이머는 두번째 박부터 재생시키고 첫 박은 play 버튼 누르자마자 우리가 재생시키자
- 해결 안됨
- 시도한 해결책 2 : 아무래도 타이머 시작시점 (deadline) 설정이 최적화되지 않은듯?
- 두번째 박자가 재생될 deadline 시점을 미리 계산해 놓고 첫박 소리를 낸 다음 timer에 주입시키자
- 해결


## 비고 <!-- (Optional) -->
Thanks to Gemini
### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?