### PR TITLE
[Feat] #495 BPM 하한 해제

### DIFF
--- a/Hanbae/Domain/UseCase/TempoImplement.swift
+++ b/Hanbae/Domain/UseCase/TempoImplement.swift
@@ -11,7 +11,7 @@ import Foundation
 class TempoImplement {
     private var jangdanRepository: JangdanRepository
     
-    static let minBPM: Int = 10
+    static let minBPM: Int = 1
     static let maxBPM: Int = 300
     
     /// 마지막 tap 시점으로부터 6초가 지났을 때 이벤트를 전달하기 위한 publisher

--- a/Hanbae/Extensions/ShapeStyle+Extension.swift
+++ b/Hanbae/Extensions/ShapeStyle+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by Yunki on 11/18/24.
 //
 
-import SwiftUICore
+import SwiftUI
 
 extension ShapeStyle {
     static var bakBarGradient: LinearGradient {


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
상령산등 기본 BPM이 낮은 장단 추가에 따른 BPM 하한선 완화

<!-- Close #495  -->

## 작업 내용
### 1. BPM 하한을 1로 낮춥니다

### 2. Xcode 업데이트하면서 발생한 문제
- SwiftUICore를 import하지 말고 그냥 SwiftUI 임포트하라고 Xcode가 화내고있었음

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?