### PR TITLE
[Fix] #496 예비박 진행중 소박보기 색상 비활성화

### DIFF
--- a/Hanbae/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Hanbae/Screen/MetronomeScreen/MetronomeView.swift
@@ -36,7 +36,12 @@ struct MetronomeView: View {
                         }
                     }
                     if let sobakSegmentCount = self.viewModel.state.currentJangdanType?.sobakSegmentCount {
-                        SobakSegmentsView(sobakSegmentCount: sobakSegmentCount, currentSobak: self.viewModel.state.currentSobak, isPlaying: self.viewModel.state.isPlaying, isSobakOn: self.viewModel.state.isSobakOn)
+                        SobakSegmentsView(
+                            sobakSegmentCount: sobakSegmentCount,
+                            currentSobak: self.viewModel.state.currentSobak,
+                            isPlaying: self.viewModel.state.isPlaying && viewModel.state.precount == nil,
+                            isSobakOn: self.viewModel.state.isSobakOn
+                        )
                     }
                 }
                 .padding(

--- a/Hanbae/Screen/MetronomeScreen/SobakSegmentView.swift
+++ b/Hanbae/Screen/MetronomeScreen/SobakSegmentView.swift
@@ -17,9 +17,7 @@ struct SobakSegmentsView: View {
         HStack(spacing: 1) {
             ForEach(0..<sobakSegmentCount, id: \.self) { index in
                 Rectangle()
-                    .foregroundStyle(isSobakOn ? isPlaying
-                                     ? self.currentSobak == index ? index == 0 ? .sobakSegmentDaebak : .sobakSegmentSobak : .frame
-                                     : .frame : .frame)
+                    .foregroundStyle(segmentStyle(for: index))
             }
         }
         .background(isSobakOn ? .bakBarBorder : .bakBarLine)
@@ -32,9 +30,15 @@ struct SobakSegmentsView: View {
         }
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
+    
+    private func segmentStyle(for index: Int) -> AnyShapeStyle {
+        guard isSobakOn, isPlaying, currentSobak == index else {
+            return AnyShapeStyle(.frame)
+        }
+        return AnyShapeStyle(index == 0 ? .sobakSegmentDaebak : .sobakSegmentSobak)
+    }
 }
 
 #Preview {
     SobakSegmentsView(sobakSegmentCount: 3, currentSobak: 2, isPlaying: true, isSobakOn: false)
 }
-


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #496  -->

## 작업 내용
### 1. 삼항연산자 간소화
- 너무 생각하기 불쾌해서 좀 간편하게 바꿨습니다.

### 2. 색상 비활성화
- 색상을 결정하는건 isPlaying이길래 해당 값 연산하는 로직에 예비박 여부 추가

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?