### PR TITLE
[Feat] #500 설정값 기기저장

### DIFF
--- a/Hanbae/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
+++ b/Hanbae/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
@@ -9,17 +9,14 @@ import Combine
 
 protocol MetronomeOnOffUseCase {
     var isPlayingPublisher: AnyPublisher<Bool, Never> { get }
-    var isSobakOnPublisher: AnyPublisher<Bool, Never> { get }
     var tickPublisher: AnyPublisher<(Int,Int,Int), Never> { get }
     var firstTickPublisher: AnyPublisher<Void, Never> { get }
     var precountPublisher: AnyPublisher<Int?, Never> { get }
     
-    func changeSobak()
     func play(withPrecount: Bool)
     func stop()
     func setSoundType()
     func initialDaeSoBakIndex()
-    func resetOptions()
 }
 
 extension MetronomeOnOffUseCase {

--- a/Hanbae/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
+++ b/Hanbae/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
@@ -15,7 +15,6 @@ protocol MetronomeOnOffUseCase {
     var precountPublisher: AnyPublisher<Int?, Never> { get }
     
     func changeSobak()
-    func changeBlink()
     func play(withPrecount: Bool)
     func stop()
     func setSoundType()

--- a/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -23,7 +23,6 @@ class MetronomeOnOffImplement {
     private var rawBpm: Double
     private var currentBeatIndex: Int
     private var isSobakOn: Bool
-    private var isBlinkOn: Bool
     
     // 현재 진행중인 박 위치 관련 변수
     private var currentSobak: Int = 0
@@ -53,7 +52,6 @@ class MetronomeOnOffImplement {
         self.rawBpm = 60.0
         self.currentBeatIndex = 0
         self.isSobakOn = false
-        self.isBlinkOn = false
         self.lastPlayTime = .now
         self.jangdanRepository = jangdanRepository
         self.soundManager = soundManager
@@ -107,10 +105,6 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     func changeSobak() {
         self.isSobakOn.toggle()
         self.isSobakOnSubject.send(self.isSobakOn)
-    }
-    
-    func changeBlink() {
-        self.isBlinkOn.toggle()
     }
     
     func play(withPrecount: Bool = false) {
@@ -192,7 +186,7 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         // timer 카운트를 해주고, 틱마다 publish
         self.updateStatePerBak()
         self.tickSubject.send((currentSobak, currentDaebak, currentRow))
-        if self.isBlinkOn && self.currentRow == 0 && self.currentDaebak == 0 && self.currentSobak == 0 {
+        if self.currentRow == 0 && self.currentDaebak == 0 && self.currentSobak == 0 {
             self.firstTickSubject.send()
         }
         
@@ -232,6 +226,5 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     
     func resetOptions() {
         self.isSobakOn = false
-        self.isBlinkOn = false
     }
 }

--- a/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Hanbae/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -12,7 +12,7 @@ import UIKit.UIApplication
 class MetronomeOnOffImplement {
     private var jangdan: [[[Accent]]]
     private var jangdanAccentList: [Accent] {
-        if self.isSobakOn {
+        if self.appState.isSobakOn {
             return jangdan.flatMap { $0 }.flatMap { $0 }
         } else {
             return jangdan.flatMap { $0 }.map { $0.enumerated().map { $0.offset == 0 ? $0.element : .none }}.flatMap { $0 }
@@ -22,7 +22,6 @@ class MetronomeOnOffImplement {
     private var bpm: Double
     private var rawBpm: Double
     private var currentBeatIndex: Int
-    private var isSobakOn: Bool
     
     // 현재 진행중인 박 위치 관련 변수
     private var currentSobak: Int = 0
@@ -45,16 +44,17 @@ class MetronomeOnOffImplement {
     private var lastPlayTime: Date
     private var jangdanRepository: JangdanRepository
     private var soundManager: PlaySoundInterface
+    private var appState: AppState
     
-    init(jangdanRepository: JangdanRepository, soundManager: PlaySoundInterface) {
+    init(jangdanRepository: JangdanRepository, soundManager: PlaySoundInterface, appState: AppState) {
         self.jangdan = [[[.medium]]]
         self.bpm = 60.0
         self.rawBpm = 60.0
         self.currentBeatIndex = 0
-        self.isSobakOn = false
         self.lastPlayTime = .now
         self.jangdanRepository = jangdanRepository
         self.soundManager = soundManager
+        self.appState = appState
         
         self.jangdanRepository.jangdanPublisher.sink { [weak self] jangdanEntity in
             guard let self else { return }
@@ -86,10 +86,6 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         self.isPlayingSubject.eraseToAnyPublisher()
     }
     
-    var isSobakOnPublisher: AnyPublisher<Bool, Never> {
-        self.isSobakOnSubject.eraseToAnyPublisher()
-    }
-    
     var tickPublisher: AnyPublisher<(Int,Int,Int), Never> {
         self.tickSubject.eraseToAnyPublisher()
     }
@@ -100,11 +96,6 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     
     var precountPublisher: AnyPublisher<Int?, Never> {
         self.precountSubject.eraseToAnyPublisher()
-    }
-    
-    func changeSobak() {
-        self.isSobakOn.toggle()
-        self.isSobakOnSubject.send(self.isSobakOn)
     }
     
     func play(withPrecount: Bool = false) {
@@ -222,9 +213,5 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         self.currentRow = self.jangdan.count - 1
         self.currentDaebak = self.jangdan[self.currentRow].count - 1
         self.currentSobak = self.jangdan[self.currentRow][self.currentDaebak].count - 1
-    }
-    
-    func resetOptions() {
-        self.isSobakOn = false
     }
 }

--- a/Hanbae/Screen/HomeScreen/ViewModel/HomeViewModel.swift
+++ b/Hanbae/Screen/HomeScreen/ViewModel/HomeViewModel.swift
@@ -15,16 +15,20 @@ class HomeViewModel {
     private var templateUseCase: TemplateUseCase
     private var metronomeOnOffUseCase: MetronomeOnOffUseCase
     private var dynamicIconUseCase: DynamicIconUseCase
+    private var appState: AppState
     
     private var cancelBag: Set<AnyCancellable> = []
     
-    init(templateUseCase: TemplateUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase, dynamicIconUseCase: DynamicIconUseCase) {
+    init(templateUseCase: TemplateUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase, dynamicIconUseCase: DynamicIconUseCase, appState: AppState) {
         self.templateUseCase = templateUseCase
         self.metronomeOnOffUseCase = metronomeOnOffUseCase
         self.dynamicIconUseCase = dynamicIconUseCase
+        self.appState = appState
         
         self.metronomeOnOffUseCase.firstTickPublisher.sink { [weak self] _ in
             guard let self else { return }
+            guard appState.isBlinkOn else { return }
+            
             self.state.isBlinking = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 withAnimation(.linear(duration: 0.3)) {

--- a/Hanbae/Screen/MetronomeScreen/MetronomeSettingControlView.swift
+++ b/Hanbae/Screen/MetronomeScreen/MetronomeSettingControlView.swift
@@ -24,7 +24,7 @@ struct MetronomeSettingControlView: View {
                 Image(self.viewModel.state.currentJangdanType?.sobakSegmentCount == nil ? .listenSobak : .viewSobak)
                     .aspectRatio(contentMode: .fit)
             }
-            .buttonStyle(MetronomeSettingToggleButtonStyle())
+            .buttonStyle(MetronomeSettingToggleButtonStyle(isOn: appState.isSobakOn))
             
             Button {
                 self.viewModel.effect(action: .changeBlinkOnOff)
@@ -32,7 +32,7 @@ struct MetronomeSettingControlView: View {
                 Image(.flash)
                     .aspectRatio(contentMode: .fit)
             }
-            .buttonStyle(MetronomeSettingToggleButtonStyle())
+            .buttonStyle(MetronomeSettingToggleButtonStyle(isOn: appState.isBlinkOn))
             
             Button {
                 self.viewModel.effect(action: .togglePrecount)

--- a/Hanbae/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Hanbae/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -77,7 +77,6 @@ class MetronomeViewModel {
         var isSobakOn: Bool = false
         var isPlaying: Bool = false
         var isTapping: Bool = false
-        var isBlinkOn: Bool = false
         var currentSobak: Int = 0
         var currentDaebak: Int = 0
         var currentRow: Int = 0
@@ -104,19 +103,16 @@ extension MetronomeViewModel {
             self.state.currentJangdanName = jangdanName
             self.templateUseCase.setJangdan(jangdanName: jangdanName)
             self.metronomeOnOffUseCase.initialDaeSoBakIndex()
-            self.state.isSobakOn = false
-            self.state.isBlinkOn = false
             self.metronomeOnOffUseCase.resetOptions()
         case .changeSobakOnOff:
-            self.state.isSobakOn.toggle()
+            self.appState.toggleSobak()
             self.metronomeOnOffUseCase.changeSobak()
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
         case .disableEstimateBpm:
             self.tempoUseCase.finishTapping()
         case .changeBlinkOnOff:
-            self.state.isBlinkOn.toggle()
-            self.metronomeOnOffUseCase.changeBlink()
+            self.appState.toggleBlink()
         case .togglePrecount:
             self.appState.togglePrecount()
         case .changeSoundType:

--- a/Hanbae/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Hanbae/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -26,6 +26,7 @@ class MetronomeViewModel {
         self.accentUseCase = accentUseCase
         self.appState = appState
         
+        self.state.isSobakOn = self.appState.isSobakOn
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
@@ -103,10 +104,9 @@ extension MetronomeViewModel {
             self.state.currentJangdanName = jangdanName
             self.templateUseCase.setJangdan(jangdanName: jangdanName)
             self.metronomeOnOffUseCase.initialDaeSoBakIndex()
-            self.metronomeOnOffUseCase.resetOptions()
         case .changeSobakOnOff:
             self.appState.toggleSobak()
-            self.metronomeOnOffUseCase.changeSobak()
+            self.state.isSobakOn.toggle()
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
         case .disableEstimateBpm:

--- a/Hanbae/System/AppState.swift
+++ b/Hanbae/System/AppState.swift
@@ -26,6 +26,8 @@ class AppState {
         self.numberOfEnteredJangdan = UserDefaults.standard.integer(forKey: "numberOfEnteredJangdan")
         self.newFeatureModal = UserDefaults.standard.bool(forKey: "newFeatureModal")
         self.newFeatureBadge = UserDefaults.standard.bool(forKey: "newFeatureBadge")
+        self.isSobakOn = UserDefaults.standard.bool(forKey: "isSobakOn")
+        self.isBlinkOn = UserDefaults.standard.bool(forKey: "isBlinkOn")
         self.precount = UserDefaults.standard.bool(forKey: "precount")
     }
     
@@ -45,6 +47,10 @@ class AppState {
     private(set) var newFeatureModal: Bool
     private(set) var newFeatureBadge: Bool
     
+    // Sobak
+    private(set) var isSobakOn: Bool
+    // Blink
+    private(set) var isBlinkOn: Bool
     // Precount
     private(set) var precount: Bool
 }
@@ -78,6 +84,16 @@ extension AppState {
     func checkNewFeatureBadge() {
         self.newFeatureBadge = true
         UserDefaults.standard.set(true, forKey: "newFeatureBadge")
+    }
+    
+    func toggleSobak() {
+        self.isSobakOn.toggle()
+        UserDefaults.standard.set(self.isSobakOn, forKey: "isSobakOn")
+    }
+    
+    func toggleBlink() {
+        self.isBlinkOn.toggle()
+        UserDefaults.standard.set(self.isBlinkOn, forKey: "isBlinkOn")
     }
     
     func togglePrecount() {

--- a/Hanbae/System/DIContainer.swift
+++ b/Hanbae/System/DIContainer.swift
@@ -19,7 +19,7 @@ class DIContainer {
         
         self.templateUseCase = TemplateImplement(jangdanRepository: self.jangdanDataSource)
         self.tempoUseCase = TempoImplement(jangdanRepository: self.jangdanDataSource)
-        self.metronomeOnOffUseCase = MetronomeOnOffImplement(jangdanRepository: self.jangdanDataSource, soundManager: self.soundManager)
+        self.metronomeOnOffUseCase = MetronomeOnOffImplement(jangdanRepository: self.jangdanDataSource, soundManager: self.soundManager, appState: self.appState)
         self.accentUseCase = AccentImplement(jangdanRepository: self.jangdanDataSource)
         self.dynamicIconUseCase = DynamicIconImplement()
         

--- a/Hanbae/System/DIContainer.swift
+++ b/Hanbae/System/DIContainer.swift
@@ -31,7 +31,7 @@ class DIContainer {
         self.controlViewModel =
         MetronomeControlViewModel(jangdanRepository: self.jangdanDataSource, tempoUseCase: self.tempoUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager, appState: self.appState, analyticsService: self.analyticsService)
         
-        self.homeViewModel = HomeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, dynamicIconUseCase: self.dynamicIconUseCase)
+        self.homeViewModel = HomeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, dynamicIconUseCase: self.dynamicIconUseCase, appState: self.appState)
         self.customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self.templateUseCase)
         self.builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
         self.customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #500  -->

## 작업 내용
### 1. isBlinkOn
- MetronomeOnOffUseCase가 Blink 여부를 책임지고 있는게 너무 복잡해보임
- 그냥 HomeView에서 AppState를 직접 참조하도록 변경
- MetronomeOnOffUseCase에서는 단순히 첫 박마다 publish 하는 책임만 갖도록 수정

### 2. isSobakOn
- 마찬가지로 MetronomeOnOffUseCase가 소박보기 설정을 관리하고있는거 별로같았음
- 싹다 들어내고 isSobakOn이 필요한 모든 곳에서 AppState를 직접 참조하도록 변경
- 사실 뷰모델이 들고있는거까지 들어내긴 귀찮아서 냅두긴 함
- 대신 뷰모델도 AppState의 isSobakOn 값에 동기화되도록 변경


## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?